### PR TITLE
Fix issue with Transaction creation

### DIFF
--- a/common/src/main/java/co/melondev/cubedpay/data/Item.java
+++ b/common/src/main/java/co/melondev/cubedpay/data/Item.java
@@ -1,7 +1,10 @@
 package co.melondev.cubedpay.data;
 
+import com.google.gson.annotations.SerializedName;
+
 public class Item {
 
+    @SerializedName("package")
     private String id = "";
     private Integer quantity = 0;
 
@@ -10,7 +13,7 @@ public class Item {
         this.quantity = quantity;
     }
 
-    public String getId() {
+    public String getPackage() {
         return id;
     }
 


### PR DESCRIPTION
There was an issue when creating a transaction that was caused by the Item object not having the proper field name.

![image](https://user-images.githubusercontent.com/7708078/45657532-65385080-bab0-11e8-8888-13ccc2f8d3bf.png)
